### PR TITLE
Improve service detail defaults and modal behaviour

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -117,9 +117,11 @@ section {
 }
 
 /* --- HERO SECTION Y CARRUSEL (INDEX) --- */
+
+/* --- HERO --- */
 .hero-section {
     width: 100%;
-    height: 75vh;
+    min-height: 80vh;
     position: relative;
     overflow: hidden;
     padding: 0;
@@ -140,24 +142,20 @@ section {
     left: 0;
     display: flex;
     align-items: center;
-    justify-content: center;
-    text-align: center;
+    justify-content: flex-start;
+    text-align: left;
     color: #fff;
-    padding: 20px;
+    padding: 60px 0;
     opacity: 0;
     visibility: hidden;
-    transition: opacity 1s ease-in-out;
+    transition: opacity 0.8s ease-in-out;
 }
 
 .carousel-slide::before {
     content: '';
     position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.4);
-    /* Overlay oscuro para legibilidad */
+    inset: 0;
+    background: linear-gradient(110deg, rgba(9, 14, 24, 0.85) 0%, rgba(9, 14, 24, 0.7) 45%, rgba(9, 14, 24, 0.1) 100%);
 }
 
 .carousel-slide.active-slide {
@@ -167,34 +165,84 @@ section {
 
 .slide-content {
     position: relative;
-    max-width: 700px;
+    max-width: 650px;
+    margin-left: 8%;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.slide-kicker {
+    font-size: 0.95rem;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    opacity: 0.75;
 }
 
 .slide-title {
-    font-size: 3.5rem;
+    font-size: clamp(2.4rem, 4vw, 3.6rem);
     font-weight: 700;
+    line-height: 1.15;
     margin: 0;
 }
 
 .slide-description {
-    font-size: 1.25rem;
-    margin: 15px 0 30px 0;
+    font-size: 1.05rem;
+    line-height: 1.6;
+    margin: 0 0 10px 0;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.slide-actions {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
 }
 
 .slide-cta-button {
-    background-color: #fff;
-    color: var(--color-text-primary);
-    padding: 15px 30px;
-    border-radius: 980px;
+    background-color: var(--color-accent);
+    color: #fff;
+    padding: 14px 28px;
+    border-radius: 999px;
     text-decoration: none;
     font-weight: 600;
     font-size: 1rem;
-    transition: all var(--transition-speed);
+    transition: transform var(--transition-speed), box-shadow var(--transition-speed);
+    box-shadow: 0 18px 35px rgba(0, 113, 227, 0.35);
 }
 
 .slide-cta-button:hover {
-    background-color: var(--color-light-gray);
-    transform: scale(1.05);
+    transform: translateY(-3px);
+    box-shadow: 0 22px 40px rgba(0, 113, 227, 0.45);
+}
+
+.slide-secondary {
+    color: #fff;
+    text-decoration: none;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 0;
+    position: relative;
+}
+
+.slide-secondary::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: -4px;
+    width: 100%;
+    height: 2px;
+    background-color: rgba(255, 255, 255, 0.45);
+    transition: transform var(--transition-speed);
+    transform-origin: left;
+    transform: scaleX(0.4);
+}
+
+.slide-secondary:hover::after {
+    transform: scaleX(1);
 }
 
 .carousel-button {
@@ -248,74 +296,504 @@ section {
 
 
 /* --- SECCIONES DE CONTENIDO (INDEX) --- */
+.section-heading {
+    text-align: center;
+    max-width: 750px;
+    margin: 0 auto 50px auto;
+}
+
+.section-subtitle {
+    color: var(--color-text-secondary);
+    font-size: 1.05rem;
+    margin-top: 16px;
+}
+
+.impact-bar {
+    background: linear-gradient(90deg, #0a1120 0%, #031d3f 100%);
+    color: #fff;
+    padding: 32px 0;
+}
+
+.impact-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 30px;
+    align-items: center;
+}
+
+.impact-item {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.95rem;
+    letter-spacing: 0.02em;
+}
+
+.impact-item strong {
+    font-size: 1.35rem;
+    font-weight: 700;
+}
+
 .featured-services {
     background-color: var(--color-light-gray);
 }
 
 .services-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(270px, 1fr));
     gap: 30px;
 }
 
 .service-card {
-    background-color: var(--color-background);
-    padding: 40px;
-    border-radius: var(--border-radius);
+    background-color: #fff;
+    border-radius: 28px;
+    overflow: hidden;
+    box-shadow: 0 18px 45px rgba(15, 23, 42, 0.08);
     transition: transform var(--transition-speed), box-shadow var(--transition-speed);
+    display: flex;
+    flex-direction: column;
+    height: 100%;
 }
 
 .service-card:hover {
     transform: translateY(-10px);
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 28px 60px rgba(15, 23, 42, 0.15);
+}
+
+.service-card__media {
+    width: 100%;
+    height: 220px;
+    object-fit: cover;
+}
+
+.service-card__body {
+    padding: 28px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    flex: 1;
 }
 
 .service-title {
-    font-size: 1.5rem;
-    margin: 0 0 10px 0;
+    font-size: 1.55rem;
+    margin: 0;
 }
 
 .service-description {
     color: var(--color-text-secondary);
-    margin-bottom: 20px;
+    margin: 0;
+}
+
+.service-actions {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
 }
 
 .service-link {
-    color: var(--color-accent);
-    text-decoration: none;
     font-weight: 600;
+    text-decoration: none;
+    color: var(--color-text-primary);
+    position: relative;
+    padding-bottom: 4px;
 }
 
-.service-link:hover {
-    text-decoration: underline;
+.service-link::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    height: 2px;
+    background-color: var(--color-text-primary);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform var(--transition-speed);
 }
 
-.trust-grid {
+.service-link:hover::after {
+    transform: scaleX(1);
+}
+
+.service-link--accent {
+    color: var(--color-accent);
+}
+
+.service-link--accent::after {
+    background-color: var(--color-accent);
+}
+
+.experience-strip {
+    padding: 90px 0;
+}
+
+.experience-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 40px;
+    gap: 60px;
+    align-items: center;
 }
 
-.trust-item {
-    text-align: center;
-}
-
-.trust-icon {
-    font-size: 2.5rem;
-    color: var(--color-accent);
+.experience-copy h2 {
+    font-size: clamp(2rem, 3.5vw, 3rem);
     margin-bottom: 20px;
 }
 
-.trust-title {
-    font-size: 1.5rem;
-    font-weight: 600;
-    margin: 0 0 10px 0;
+.experience-copy p {
+    color: var(--color-text-secondary);
+    margin-bottom: 24px;
 }
 
-.trust-description {
+.experience-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 24px 0;
+    display: grid;
+    gap: 12px;
+}
+
+.experience-list li {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.experience-list i {
+    color: var(--color-accent);
+    font-size: 1.1rem;
+}
+
+.experience-media {
+    position: relative;
+}
+
+.experience-media img {
+    width: 100%;
+    border-radius: 28px;
+    box-shadow: 0 25px 60px rgba(15, 23, 42, 0.18);
+    object-fit: cover;
+}
+
+.experience-badge {
+    position: absolute;
+    bottom: 20px;
+    left: 20px;
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: 16px;
+    padding: 18px 22px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    box-shadow: 0 15px 35px rgba(15, 23, 42, 0.16);
+}
+
+.experience-badge strong {
+    font-size: 1.2rem;
+}
+
+.button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    border-radius: 999px;
+    padding: 14px 28px;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform var(--transition-speed), box-shadow var(--transition-speed);
+    cursor: pointer;
+}
+
+.button-primary {
+    background: var(--color-accent);
+    color: #fff;
+    box-shadow: 0 18px 35px rgba(0, 113, 227, 0.35);
+}
+
+.button-primary:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 22px 45px rgba(0, 113, 227, 0.45);
+}
+
+.button-outline {
+    border: 1px solid rgba(15, 23, 42, 0.15);
+    color: var(--color-text-primary);
+    background-color: transparent;
+}
+
+.button-outline:hover {
+    transform: translateY(-3px);
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+}
+
+.button-ghost {
+    background-color: transparent;
+    color: var(--color-text-primary);
+}
+
+.button-ghost:hover {
+    color: var(--color-accent);
+    transform: translateY(-3px);
+}
+
+.products-highlight {
+    background: var(--color-light-gray);
+}
+
+.product-highlight-card {
+    background-color: #fff;
+    border-radius: 32px;
+    overflow: hidden;
+    box-shadow: 0 20px 50px rgba(15, 23, 42, 0.12);
+    transition: transform var(--transition-speed), box-shadow var(--transition-speed);
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.product-highlight-card:hover {
+    transform: translateY(-10px);
+    box-shadow: 0 28px 70px rgba(15, 23, 42, 0.18);
+}
+
+.product-highlight-card__media {
+    width: 100%;
+    height: 230px;
+    object-fit: cover;
+}
+
+.product-highlight-card__body {
+    padding: 30px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    flex: 1;
+}
+
+.product-tag {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.3em;
     color: var(--color-text-secondary);
-    max-width: 35ch;
-    margin: 0 auto;
+}
+
+.products-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 30px;
+}
+
+.products-cta {
+    margin-top: 40px;
+    display: flex;
+    gap: 18px;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+/* --- PÁGINA DE PRODUCTOS --- */
+.products-hero {
+    padding: 120px 0 90px 0;
+    background: linear-gradient(120deg, #0f172a 0%, #1d3e72 100%);
+    color: #fff;
+}
+
+.products-hero__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 60px;
+    align-items: center;
+}
+
+.products-hero__kicker {
+    letter-spacing: 0.35em;
+    text-transform: uppercase;
+    font-size: 0.85rem;
+    opacity: 0.65;
+}
+
+.products-hero__content h1 {
+    font-size: clamp(2.4rem, 4vw, 3.5rem);
+    margin: 22px 0;
+}
+
+.products-hero__content p {
+    color: rgba(255, 255, 255, 0.85);
+    margin-bottom: 28px;
+}
+
+.products-hero__actions {
+    display: flex;
+    gap: 18px;
+    flex-wrap: wrap;
+    margin-bottom: 24px;
+}
+
+.products-hero__benefits {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 12px;
+}
+
+.products-hero__benefits li {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.products-hero__benefits i {
+    color: var(--color-accent);
+}
+
+.products-hero__media {
+    position: relative;
+}
+
+.products-hero__media img {
+    width: 100%;
+    border-radius: 24px;
+    box-shadow: 0 28px 65px rgba(0, 0, 0, 0.28);
+    object-fit: cover;
+}
+
+.products-hero__badge {
+    position: absolute;
+    bottom: 20px;
+    left: 20px;
+    background: rgba(255, 255, 255, 0.9);
+    color: var(--color-text-primary);
+    padding: 18px 22px;
+    border-radius: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    box-shadow: 0 22px 45px rgba(15, 23, 42, 0.25);
+}
+
+.category-showcase {
+    padding: 90px 0;
+}
+
+.category-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 30px;
+}
+
+.category-card {
+    background: #fff;
+    border-radius: 28px;
+    overflow: hidden;
+    box-shadow: 0 18px 45px rgba(15, 23, 42, 0.12);
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    transition: transform var(--transition-speed), box-shadow var(--transition-speed);
+}
+
+.category-card:hover {
+    transform: translateY(-8px);
+    box-shadow: 0 28px 65px rgba(15, 23, 42, 0.18);
+}
+
+.category-card__media {
+    width: 100%;
+    height: 210px;
+    object-fit: cover;
+}
+
+.category-card__body {
+    padding: 28px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    flex: 1;
+}
+
+.catalog-grid {
+    margin-top: 40px;
+    gap: 35px;
+}
+
+.product-card {
+    border-radius: 26px;
+    overflow: hidden;
+    box-shadow: 0 15px 35px rgba(15, 23, 42, 0.1);
+    transition: transform var(--transition-speed), box-shadow var(--transition-speed);
+}
+
+.product-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 25px 55px rgba(15, 23, 42, 0.16);
+}
+
+.before-after {
+    padding: 100px 0;
+}
+
+.before-after__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 50px;
+    align-items: center;
+}
+
+.before-after__media img {
+    width: 100%;
+    border-radius: 28px;
+    box-shadow: 0 18px 45px rgba(15, 23, 42, 0.15);
+    object-fit: cover;
+}
+
+.testimonial {
+    margin: 30px 0;
+    padding-left: 20px;
+    border-left: 4px solid var(--color-accent);
+}
+
+.testimonial blockquote {
+    font-size: 1.1rem;
+    margin: 0;
+    color: var(--color-text-secondary);
+}
+
+.testimonial cite {
+    display: block;
+    margin-top: 10px;
+    font-weight: 600;
+}
+
+.cta-final {
+    background: linear-gradient(120deg, #031d3f 0%, #0f2f6b 100%);
+    color: #fff;
+    padding: 80px 0;
+}
+
+.cta-final__content {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 30px;
+}
+
+.cta-final__text h2 {
+    font-size: clamp(2rem, 3vw, 3rem);
+    margin-bottom: 14px;
+}
+
+.cta-final__text p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.cta-final__actions {
+    display: flex;
+    gap: 18px;
+    flex-wrap: wrap;
 }
 
 
@@ -506,6 +984,205 @@ section {
     text-decoration: underline;
 }
 
+/* --- SERVICIOS DETALLE --- */
+.service-hero {
+    padding: 120px 0 80px 0;
+    background: linear-gradient(120deg, #031d3f 0%, #0f2f6b 100%);
+    color: #fff;
+}
+
+.service-hero__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 60px;
+    align-items: center;
+}
+
+.service-hero__kicker {
+    letter-spacing: 0.35em;
+    text-transform: uppercase;
+    font-size: 0.85rem;
+    opacity: 0.7;
+}
+
+.service-hero__content h1 {
+    font-size: clamp(2.4rem, 4vw, 3.4rem);
+    margin: 20px 0;
+}
+
+.service-hero__content p {
+    color: rgba(255, 255, 255, 0.85);
+    margin-bottom: 30px;
+}
+
+.service-hero__cta {
+    display: flex;
+    gap: 18px;
+    flex-wrap: wrap;
+    margin-bottom: 24px;
+}
+
+.service-hero__highlights {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 12px;
+}
+
+.service-hero__highlights li {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.service-hero__highlights i {
+    color: var(--color-accent);
+}
+
+.service-hero__media {
+    position: relative;
+}
+
+.service-hero__media img {
+    width: 100%;
+    border-radius: 24px;
+    box-shadow: 0 25px 60px rgba(0, 0, 0, 0.25);
+    object-fit: cover;
+}
+
+.service-hero__badge {
+    position: absolute;
+    bottom: 20px;
+    right: 20px;
+    background: rgba(255, 255, 255, 0.9);
+    color: var(--color-text-primary);
+    padding: 18px 22px;
+    border-radius: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-weight: 600;
+    box-shadow: 0 18px 45px rgba(15, 23, 42, 0.25);
+}
+
+.service-intro {
+    padding: 80px 0;
+}
+
+.service-intro__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 40px;
+    align-items: center;
+}
+
+.service-intro__copy h2 {
+    font-size: clamp(2rem, 3.2vw, 2.8rem);
+    margin-bottom: 18px;
+}
+
+.service-intro__copy p {
+    color: var(--color-text-secondary);
+    margin: 0;
+}
+
+.service-intro__guarantees {
+    display: grid;
+    gap: 20px;
+}
+
+.guarantee-card {
+    background: var(--color-light-gray);
+    border-radius: 20px;
+    padding: 30px;
+    display: grid;
+    gap: 12px;
+}
+
+.guarantee-card i {
+    font-size: 1.8rem;
+    color: var(--color-accent);
+}
+
+.service-process {
+    background: var(--color-light-gray);
+    padding: 100px 0;
+}
+
+.process-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 30px;
+}
+
+.process-card {
+    background: #fff;
+    border-radius: 22px;
+    padding: 30px;
+    box-shadow: 0 15px 35px rgba(15, 23, 42, 0.08);
+    display: grid;
+    gap: 14px;
+}
+
+.process-number {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+}
+
+.service-trust {
+    padding: 100px 0;
+}
+
+.service-trust__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 50px;
+    align-items: center;
+}
+
+.service-trust__copy p {
+    color: var(--color-text-secondary);
+    margin: 20px 0;
+}
+
+.service-trust__media {
+    position: relative;
+}
+
+.service-trust__media img {
+    width: 100%;
+    border-radius: 24px;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+    object-fit: cover;
+}
+
+.service-trust__quote {
+    position: absolute;
+    bottom: -30px;
+    left: 20px;
+    right: 20px;
+    background: #fff;
+    border-radius: 18px;
+    padding: 24px;
+    box-shadow: 0 18px 45px rgba(15, 23, 42, 0.1);
+    font-weight: 500;
+    display: grid;
+    gap: 12px;
+}
+
+.service-trust__quote span {
+    font-size: 0.9rem;
+    color: var(--color-text-secondary);
+}
+
 /* --- MODAL DE WHATSAPP --- */
 .modal-overlay {
     position: fixed;
@@ -626,37 +1303,39 @@ section {
 
 .products-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     gap: 30px;
 }
 
 .product-card {
     background: #fff;
-    border: 1px solid #eee;
-    border-radius: var(--border-radius);
+    border-radius: 26px;
     overflow: hidden;
-    text-align: center;
-    transition: all var(--transition-speed);
+    text-align: left;
+    box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+    transition: transform var(--transition-speed), box-shadow var(--transition-speed);
 }
 
 .product-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+    transform: translateY(-6px);
+    box-shadow: 0 24px 55px rgba(15, 23, 42, 0.16);
 }
 
 .product-card img {
     width: 100%;
-    height: 250px;
+    height: 220px;
     object-fit: cover;
 }
 
 .product-info {
-    padding: 25px;
+    padding: 26px;
+    display: grid;
+    gap: 12px;
 }
 
 .product-name {
-    font-size: 1.4rem;
-    margin: 0 0 5px 0;
+    font-size: 1.35rem;
+    margin: 0;
 }
 
 .product-spec {
@@ -762,77 +1441,192 @@ section {
 
 /* --- PÁGINA NOSOTROS --- */
 
-/* Título de la página */
-.page__title-section {
-    text-align: center;
-    padding: 60px 0;
+.about-hero {
+    padding: 120px 0 80px 0;
+    background: linear-gradient(120deg, #031d3f 0%, #0f2f6b 100%);
+    color: #fff;
 }
 
-.page__title-container h1 {
-    font-size: 3rem;
-    margin-bottom: 15px;
-}
-
-.page__title-container p {
-    font-size: 1.2rem;
-    color: var(--color-text-secondary);
-    max-width: 60ch;
-    margin: 0 auto;
-}
-
-/* Sección "Nuestra Historia" */
-.about__grid {
+.about-hero__grid {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     gap: 60px;
     align-items: center;
 }
 
-.about__img {
+.about-hero__kicker {
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    font-size: 0.85rem;
+    opacity: 0.7;
+}
+
+.about-hero__content h1 {
+    font-size: clamp(2.5rem, 4vw, 3.6rem);
+    margin: 20px 0;
+}
+
+.about-hero__content p {
+    color: rgba(255, 255, 255, 0.85);
+    margin-bottom: 28px;
+}
+
+.about-hero__cta {
+    display: flex;
+    gap: 18px;
+    flex-wrap: wrap;
+}
+
+.about-hero__media {
+    position: relative;
+}
+
+.about-hero__media img {
     width: 100%;
-    border-radius: var(--border-radius);
-    box-shadow: 0 15px 30px rgba(0,0,0,0.1);
+    border-radius: 24px;
+    box-shadow: 0 28px 65px rgba(0, 0, 0, 0.25);
+    object-fit: cover;
 }
 
-.about__content h2 {
-    font-size: 2.5rem;
-    margin-bottom: 20px;
+.about-hero__badge {
+    position: absolute;
+    bottom: 20px;
+    right: 20px;
+    background: rgba(255, 255, 255, 0.9);
+    color: var(--color-text-primary);
+    padding: 18px 22px;
+    border-radius: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-weight: 600;
+    box-shadow: 0 22px 45px rgba(15, 23, 42, 0.25);
 }
 
-.about__content p {
-    color: var(--color-text-secondary);
-    font-size: 1.1rem;
-    line-height: 1.7;
+.about-story {
+    padding: 90px 0;
 }
 
-/* Sección "Misión y Visión" */
-.mv__grid {
+.about-story__grid {
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 40px;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 50px;
+    align-items: center;
 }
 
-.mv__card {
-    background-color: var(--color-background);
-    padding: 40px;
-    border-radius: var(--border-radius);
-    transition: transform var(--transition-speed), box-shadow var(--transition-speed);
+.about-story__media img {
+    width: 100%;
+    border-radius: 24px;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+    object-fit: cover;
 }
 
-.mv__card:hover {
-    transform: translateY(-8px);
-    box-shadow: 0 20px 40px rgba(0,0,0,0.08);
+.about-story__content h2 {
+    font-size: clamp(2.1rem, 3.5vw, 3rem);
+    margin-bottom: 18px;
 }
 
-.mv__card h3 {
-    font-size: 1.8rem;
-    color: var(--color-accent);
-    margin: 0 0 15px 0;
-}
-
-.mv__card p {
+.about-story__content p {
     color: var(--color-text-secondary);
+    margin-bottom: 22px;
+}
+
+.about-story__list {
+    list-style: none;
+    padding: 0;
     margin: 0;
+    display: grid;
+    gap: 12px;
+}
+
+.about-story__list li {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    color: var(--color-text-secondary);
+}
+
+.about-story__list i {
+    color: var(--color-accent);
+}
+
+.mission-vision {
+    background: var(--color-light-gray);
+    padding: 90px 0;
+}
+
+.mission-vision__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 30px;
+}
+
+.mission-card {
+    background: #fff;
+    border-radius: 24px;
+    padding: 32px;
+    box-shadow: 0 15px 40px rgba(15, 23, 42, 0.08);
+    display: grid;
+    gap: 16px;
+}
+
+.mission-card ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 10px;
+    color: var(--color-text-secondary);
+}
+
+.about-numbers {
+    padding: 80px 0;
+}
+
+.about-numbers__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 30px;
+    text-align: center;
+}
+
+.about-number {
+    background: var(--color-light-gray);
+    border-radius: 24px;
+    padding: 40px 30px;
+    display: grid;
+    gap: 12px;
+}
+
+.about-number strong {
+    font-size: 2.2rem;
+}
+
+.about-number span {
+    color: var(--color-text-secondary);
+}
+
+.team-section {
+    padding: 90px 0;
+}
+
+.team-section__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 50px;
+    align-items: center;
+}
+
+.team-section__content p {
+    color: var(--color-text-secondary);
+    margin: 20px 0;
+}
+
+.team-section__media img {
+    width: 100%;
+    border-radius: 24px;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+    object-fit: cover;
 }
 
 
@@ -854,18 +1648,31 @@ section {
         grid-template-columns: 1fr;
     }
 
-    .page__title-container h1 {
-        font-size: 2.5rem;
+    .carousel-slide {
+        padding: 90px 0;
+        justify-content: center;
     }
 
-    .about__grid,
-    .mv__grid {
+    .slide-content {
+        margin-left: 24px;
+        margin-right: 24px;
+    }
+
+    .impact-grid,
+    .experience-grid,
+    .products-hero__grid,
+    .category-grid,
+    .catalog-grid,
+    .process-grid,
+    .before-after__grid,
+    .products-grid,
+    .about-hero__grid,
+    .about-story__grid,
+    .mission-vision__grid,
+    .about-numbers__grid,
+    .team-section__grid {
         grid-template-columns: 1fr;
-        gap: 40px;
-    }
-
-    .about__img {
-        order: -1; /* Pone la imagen arriba en móvil */
+        gap: 30px;
     }
 
     .footer-grid {

--- a/index.html
+++ b/index.html
@@ -30,91 +30,236 @@
             <div class="carousel-container">
 
                 <div class="carousel-slide active-slide"
-                    style="background-image: url('assets/images/Pantalla-reparada-hero.png');">
+                    style="background-image: url('assets/images/tecnico-reparando-telefono.png');">
                     <div class="slide-content">
-                        <h1 class="slide-title">¿Pantalla rota? La dejamos como nueva.</h1>
-                        <p class="slide-description">Reparaciones con componentes de alta calidad y garantía.</p>
-                        <a href="servicios.html#pantallas" class="slide-cta-button">Reparar mi pantalla</a>
+                        <span class="slide-kicker">Laboratorio express en Piura</span>
+                        <h1 class="slide-title">Reparamos tu smartphone y lo devolvemos a la vida el mismo día.</h1>
+                        <p class="slide-description">Diagnóstico profesional al ingreso, repuestos premium certificados y garantía real por
+                            escrito.</p>
+                        <div class="slide-actions">
+                            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20agendar%20una%20reparaci%C3%B3n." target="_blank"
+                                class="slide-cta-button">Quiero mi cotización</a>
+                            <a href="servicios.html" class="slide-secondary">Ver servicios</a>
+                        </div>
                     </div>
                 </div>
 
                 <div class="carousel-slide"
-                    style="background-image: url('assets/images/Batería-reparada-hero.png');">
+                    style="background-image: url('assets/images/Batería-hero-cambiandose.png');">
                     <div class="slide-content">
-                        <h1 class="slide-title">¿Tu batería ya no dura? Cámbiala en 20 minutos.</h1>
-                        <p class="slide-description">Recupera la autonomía de tu iPhone al instante.</p>
-                        <a href="servicios.html#baterias" class="slide-cta-button">Cambiar mi batería</a>
+                        <span class="slide-kicker">Cambio de batería en 20 minutos</span>
+                        <h2 class="slide-title">Energía nueva para tu iPhone sin perder tus datos.</h2>
+                        <p class="slide-description">Baterías Voltrax y originales de fábrica, instaladas por técnicos certificados.</p>
+                        <div class="slide-actions">
+                            <a href="servicios.html#detail-bateria" class="slide-cta-button">Agenda tu cambio</a>
+                            <a href="productos.html#baterias" class="slide-secondary">Ver baterías</a>
+                        </div>
                     </div>
                 </div>
 
                 <div class="carousel-slide"
                     style="background-image: url('assets/images/iphone-honor-presentación-hero.png');">
                     <div class="slide-content">
-                        <h1 class="slide-title">Estrena equipo nuevo con 1 año de garantía.</h1>
-                        <p class="slide-description">Los mejores modelos de iPhone y Android a tu alcance.</p>
-                        <a href="productos.html" class="slide-cta-button">Ver equipos</a>
+                        <span class="slide-kicker">Zona de estrenos</span>
+                        <h2 class="slide-title">Teléfonos y accesorios listos para entregar hoy mismo.</h2>
+                        <p class="slide-description">Equipos nuevos y reacondicionados con garantía hasta por 12 meses y planes de
+                            equipamiento corporativo.</p>
+                        <div class="slide-actions">
+                            <a href="productos.html" class="slide-cta-button">Descubrir catálogo</a>
+                            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20comprar%20un%20equipo." target="_blank"
+                                class="slide-secondary">Solicitar asesor</a>
+                        </div>
                     </div>
                 </div>
 
             </div>
 
-            <button class="carousel-button prev">&#10094;</button>
-            <button class="carousel-button next">&#10095;</button>
+            <button class="carousel-button prev" aria-label="Anterior">&#10094;</button>
+            <button class="carousel-button next" aria-label="Siguiente">&#10095;</button>
 
-            <div class="carousel-dots">
-                <span class="dot active-dot"></span>
-                <span class="dot"></span>
-                <span class="dot"></span>
+            <div class="carousel-dots" role="tablist">
+                <span class="dot active-dot" role="tab" aria-label="Reparaciones express"></span>
+                <span class="dot" role="tab" aria-label="Cambio de batería"></span>
+                <span class="dot" role="tab" aria-label="Catálogo de productos"></span>
+            </div>
+        </section>
+
+        <section class="impact-bar">
+            <div class="container impact-grid">
+                <div class="impact-item">
+                    <strong>+10 años</strong>
+                    <span>especialistas certificados Apple &amp; Android</span>
+                </div>
+                <div class="impact-item">
+                    <strong>+25 000</strong>
+                    <span>equipos reparados con garantía</span>
+                </div>
+                <div class="impact-item">
+                    <strong>Servicio express</strong>
+                    <span>Cambio de batería en 20 minutos</span>
+                </div>
+                <div class="impact-item">
+                    <strong>Catálogo premium</strong>
+                    <span>Teléfonos, cargadores y audio listos para entrega</span>
+                </div>
             </div>
         </section>
 
         <section class="featured-services">
             <div class="container">
-                <h2 class="section-title">Soluciones al instante para tus dispositivos</h2>
+                <div class="section-heading">
+                    <h2 class="section-title">Soluciones que enamoran a tus clientes y a tu bolsillo</h2>
+                    <p class="section-subtitle">Reparamos, potenciamos y equipamos con repuestos premium y soporte humano real.</p>
+                </div>
                 <div class="services-grid">
                     <article class="service-card">
-                        <h3 class="service-title">Cambio de Batería</h3>
-                        <p class="service-description">Recupera tu autonomía. Para iPhone, ¡lista en 20 minutos!</p>
-                        <a href="servicios.html#baterias" class="service-link">Ver más →</a>
+                        <img src="assets/images/Pantalla-rota-antes-despues.webp" alt="Cambio de pantalla antes y después"
+                            class="service-card__media">
+                        <div class="service-card__body">
+                            <h3 class="service-title">Pantallas perfectas</h3>
+                            <p class="service-description">Antes y después en cuestión de horas. Pantallas OLED y LCD con brillo original y
+                                garantía certificada.</p>
+                            <div class="service-actions">
+                                <a href="servicios.html#detail-pantallas" class="service-link">Ver opciones</a>
+                                <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20necesito%20cambiar%20la%20pantalla%20de%20mi%20tel%C3%A9fono." target="_blank"
+                                    class="service-link service-link--accent"><i class="fab fa-whatsapp"></i> Cotizar ya</a>
+                            </div>
+                        </div>
                     </article>
                     <article class="service-card">
-                        <h3 class="service-title">Cambio de Pantalla</h3>
-                        <p class="service-description">Visión perfecta con pantallas de la más alta calidad.</p>
-                        <a href="servicios.html#pantallas" class="service-link">Ver más →</a>
+                        <img src="assets/images/bateria-iphone-voltrax.webp" alt="Batería Voltrax de reemplazo"
+                            class="service-card__media">
+                        <div class="service-card__body">
+                            <h3 class="service-title">Baterías con sello premium</h3>
+                            <p class="service-description">Voltrax, originales y OEM. Instalada en 20 minutos mientras disfrutas de nuestra zona de
+                                clientes.</p>
+                            <div class="service-actions">
+                                <a href="servicios.html#detail-bateria" class="service-link">Ver servicios</a>
+                                <a href="productos.html#baterias" class="service-link service-link--accent">Ver catálogo</a>
+                            </div>
+                        </div>
                     </article>
                     <article class="service-card">
-                        <h3 class="service-title">Problemas de Carga</h3>
-                        <p class="service-description">Solucionamos cualquier fallo en el puerto de carga o batería.</p>
-                        <a href="servicios.html#carga" class="service-link">Ver más →</a>
-                    </article>
-                    <article class="service-card">
-                        <h3 class="service-title">Cambio de Tapa</h3>
-                        <p class="service-description">Devolvemos la estética impecable y original a tu equipo.</p>
-                        <a href="servicios.html#tapas" class="service-link">Ver más →</a>
+                        <img src="assets/images/cambio-de-camara.webp" alt="Repuesto de cámara"
+                            class="service-card__media">
+                        <div class="service-card__body">
+                            <h3 class="service-title">Foto y video como nuevos</h3>
+                            <p class="service-description">Reemplazo de módulos, cristal de lente, limpieza profesional y recalibración de software.</p>
+                            <div class="service-actions">
+                                <a href="servicios.html#detail-camaras" class="service-link">Más detalles</a>
+                                <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20reparar%20la%20c%C3%A1mara%20de%20mi%20equipo." target="_blank"
+                                    class="service-link service-link--accent"><i class="fab fa-whatsapp"></i> Agenda ahora</a>
+                            </div>
+                        </div>
                     </article>
                 </div>
             </div>
         </section>
 
-        <section class="trust-section">
+        <section class="experience-strip">
+            <div class="container experience-grid">
+                <div class="experience-copy">
+                    <h2>Tu smartphone listo hoy mismo.</h2>
+                    <p>Ingresas tu equipo, hacemos diagnóstico inmediato, autorizas la reparación y recibes evidencia del proceso en
+                        tiempo real. Así convertimos emergencias en reseñas de 5 estrellas.</p>
+                    <ul class="experience-list">
+                        <li><i class="fa-solid fa-shield-heart"></i> Piezas con garantía real y sello de autenticidad.</li>
+                        <li><i class="fa-solid fa-camera"></i> Registro fotográfico antes, durante y después de la intervención.</li>
+                        <li><i class="fa-solid fa-message-dots"></i> WhatsApp activo para dudas, seguimiento y soporte post venta.</li>
+                    </ul>
+                    <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20agendar%20una%20revisi%C3%B3n%20para%20mi%20equipo." target="_blank"
+                        class="button button-primary">Quiero reservar mi turno</a>
+                </div>
+                <div class="experience-media">
+                    <img src="assets/images/telefonos-en-exhibicion.png" alt="Vitrina de teléfonos en iPro Perú">
+                    <div class="experience-badge">
+                        <strong>Listo en 90'</strong>
+                        <span>para reparaciones avanzadas</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="products-highlight" id="destacados">
             <div class="container">
-                <h2 class="section-title">Por qué confiar en iProPerú</h2>
-                <div class="trust-grid">
-                    <div class="trust-item">
-                        <i class="fas fa-history trust-icon"></i>
-                        <h3 class="trust-title">10+ Años de Experiencia</h3>
-                        <p class="trust-description">Una década de soluciones y clientes satisfechos nos respaldan.</p>
+                <div class="section-heading">
+                    <h2 class="section-title">Equipos y accesorios que tus manos quieren tocar</h2>
+                    <p class="section-subtitle">Stock confirmado cada semana, entregas inmediatas y asesoría para elegir el match perfecto.</p>
+                </div>
+                <div class="products-grid">
+                    <article class="product-highlight-card">
+                        <img src="assets/images/iphone-promax-15.webp" alt="iPhone 15 Pro Max" class="product-highlight-card__media">
+                        <div class="product-highlight-card__body">
+                            <span class="product-tag">iPhone</span>
+                            <h3>iPhone 15 Pro Max</h3>
+                            <p>Titanio Natural. Incluye protector premium, activación y migración de datos.</p>
+                            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20el%20iPhone%2015%20Pro%20Max." target="_blank"
+                                class="button button-outline"><i class="fab fa-whatsapp"></i> Apartar unidad</a>
+                        </div>
+                    </article>
+                    <article class="product-highlight-card">
+                        <img src="assets/images/producto-supercargadores-portatiles.webp" alt="Powerbanks portátiles"
+                            class="product-highlight-card__media">
+                        <div class="product-highlight-card__body">
+                            <span class="product-tag">Powerbanks</span>
+                            <h3>Super cargadores portátiles</h3>
+                            <p>Powerbanks iluminados de alta capacidad para tus viajes, eventos y jornadas largas.</p>
+                            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20powerbanks%20para%20mi%20equipo." target="_blank"
+                                class="button button-outline"><i class="fab fa-whatsapp"></i> Cotizar packs</a>
+                        </div>
+                    </article>
+                    <article class="product-highlight-card">
+                        <img src="assets/images/Altavoces-de-sonido-tematica-transformes.webp" alt="Altavoces temáticos"
+                            class="product-highlight-card__media">
+                        <div class="product-highlight-card__body">
+                            <span class="product-tag">Audio</span>
+                            <h3>Altavoces edición Transformers</h3>
+                            <p>Luces RGB, bajos potentes y diseño coleccionable. Perfectos para stands y regalos corporativos.</p>
+                            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20los%20altavoces%20tem%C3%A1ticos." target="_blank"
+                                class="button button-outline"><i class="fab fa-whatsapp"></i> Pedir demostración</a>
+                        </div>
+                    </article>
+                </div>
+                <div class="products-cta">
+                    <a href="productos.html" class="button button-primary">Ver todo el catálogo</a>
+                    <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20asesor%C3%ADa%20para%20comprar." target="_blank"
+                        class="button button-ghost">Hablar con un asesor</a>
+                </div>
+            </div>
+        </section>
+
+        <section class="before-after">
+            <div class="container before-after__grid">
+                <div class="before-after__media">
+                    <img src="assets/images/Pantalla-rota-antes-despues.webp" alt="Antes y después de reparación">
+                </div>
+                <div class="before-after__content">
+                    <h2>Antes y después que inspiran confianza</h2>
+                    <p>Nuestros clientes llegan recomendados porque viven la experiencia iPro Perú: comunicación clara, entregas puntuales y
+                        resultados que enamoran.</p>
+                    <div class="testimonial">
+                        <blockquote>
+                            “Llevé mi iPhone con la pantalla destruida y en dos horas parecía recién comprado. Además enviaron fotos del proceso. ¡Servicio 10/10!”
+                        </blockquote>
+                        <cite>— Katherine M., emprendedora digital</cite>
                     </div>
-                    <div class="trust-item">
-                        <i class="fas fa-globe trust-icon"></i>
-                        <h3 class="trust-title">Capacitación Internacional</h3>
-                        <p class="trust-description">Nuestro personal se capacita constantemente en el extranjero.</p>
-                    </div>
-                    <div class="trust-item">
-                        <i class="fas fa-bolt trust-icon"></i>
-                        <h3 class="trust-title">Rapidez y Eficiencia</h3>
-                        <p class="trust-description">Servicios express como el cambio de batería en 20 minutos.</p>
-                    </div>
+                    <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20agendar%20una%20visita." target="_blank"
+                        class="button button-primary">Agendar visita al local</a>
+                </div>
+            </div>
+        </section>
+
+        <section class="cta-final">
+            <div class="container cta-final__content">
+                <div class="cta-final__text">
+                    <h2>¿Listo para enamorarte de tu equipo otra vez?</h2>
+                    <p>Escríbenos por WhatsApp, agenda tu cita y vive el servicio técnico número uno de Piura.</p>
+                </div>
+                <div class="cta-final__actions">
+                    <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20cotizar%20una%20reparaci%C3%B3n." target="_blank"
+                        class="button button-primary"><i class="fab fa-whatsapp"></i> Escribir ahora</a>
+                    <a href="tel:+51979012180" class="button button-ghost"><i class="fa-solid fa-phone"></i> Llamar al
+                        979&nbsp;012&nbsp;180</a>
                 </div>
             </div>
         </section>

--- a/nosotros.html
+++ b/nosotros.html
@@ -13,40 +13,108 @@
     <div id="header-placeholder"></div>
 
     <main>
-        <section class="page__title-section" style="background-color: var(--color-light-gray);">
-            <div class="page__title-container container">
-                <h1>Quiénes Somos</h1>
-                <p>Más de 10 años transformando problemas tecnológicos en soluciones prácticas.</p>
-            </div>
-        </section>
-
-        <section class="about__section section container">
-            <div class="about__grid">
-                <div class="about__image">
-                    <img src="assets/images/personal.png" alt="personal de iPro Perú" class="about__img">
-                </div>
-                <div class="about__content">
-                    <h2>Nuestra Historia</h2>
-                    <p>En iPro Perú, transformamos los problemas tecnológicos en soluciones prácticas. Contamos con más 10 años de experiencia y nuestros equipos cuentan con garantía de 1 año de fábrica. Nuestro objetivo es brindar soluciones integrales en venta y reparación de iPhone y Android, con productos de calidad, sumando una asesoría personalizada y un servicio técnico confiable.</p>
-                </div>
-            </div>
-        </section>
-
-        <section class="mission-vision__section section" style="background-color: var(--color-light-gray);">
-            <div class="mission-vision__container container">
-                <div class="mv__grid">
-                    <div class="mv__card">
-                        <h3>Misión</h3>
-                        <p>Brindar la mejor experiencia en cada atención y servicio a nuestros clientes priorizando una atención de alto nivel, innovando y generando valor para nuestro público en general, enfocados a satisfacer con nuestros servicios a todos nuestros clientes particulares y corporativos, buscando estar un paso adelante que nuestra competencia.</p>
+        <section class="about-hero">
+            <div class="container about-hero__grid">
+                <div class="about-hero__content">
+                    <span class="about-hero__kicker">Somos iPro Perú</span>
+                    <h1>Un laboratorio tecnológico que vive para sorprenderte.</h1>
+                    <p>Hace más de una década convertimos urgencias tecnológicas en historias de éxito. Hoy acompañamos a familias, empresas y creadores con soluciones integrales en reparación, venta y actualización de smartphones.</p>
+                    <div class="about-hero__cta">
+                        <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20conocer%20sus%20servicios." target="_blank" class="button button-primary">Hablemos por WhatsApp</a>
+                        <a href="servicios.html" class="button button-outline">Ver servicios</a>
                     </div>
-                    <div class="mv__card">
-                        <h3>Visión</h3>
-                        <p>Ser la empresa lider en tecnología móvil en la región, reconocida por su innovación, confiabilidad y excelencia en servicio técnico para equipos iPhone y Android, con un laboratorio de vanguardia y un equipo profesional que marca la diferencia.</p>
+                </div>
+                <div class="about-hero__media">
+                    <img src="assets/images/personal.png" alt="Equipo iPro Perú">
+                    <div class="about-hero__badge">
+                        <strong>+10 años</strong>
+                        <span>apasionados por la tecnología móvil</span>
                     </div>
                 </div>
             </div>
         </section>
-        
+
+        <section class="about-story">
+            <div class="container about-story__grid">
+                <div class="about-story__media">
+                    <img src="assets/images/telefonos-en-exhibicion.png" alt="Vitrina del local iPro Perú">
+                </div>
+                <div class="about-story__content">
+                    <h2>Nacimos para elevar el servicio técnico en Piura.</h2>
+                    <p>Iniciamos como un pequeño laboratorio apasionado por los iPhone. Hoy atendemos todas las marcas líderes, con protocolos de calidad que aseguran un resultado impecable y una experiencia inolvidable.</p>
+                    <ul class="about-story__list">
+                        <li><i class="fa-solid fa-screwdriver-wrench"></i> Laboratorio antiestático equipado con herramientas de precisión.</li>
+                        <li><i class="fa-solid fa-user-tie"></i> Equipo certificado en Estados Unidos, México y Colombia.</li>
+                        <li><i class="fa-solid fa-star"></i> Garantía y seguimiento postventa que se traduce en reseñas de 5 estrellas.</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section class="mission-vision">
+            <div class="container mission-vision__grid">
+                <div class="mission-card">
+                    <h3>Misión</h3>
+                    <p>Impulsar a las personas y negocios de Piura a mantenerse conectados, productivos e inspirados a través de servicios y productos móviles confiables, transparentes y llenos de calidez humana.</p>
+                </div>
+                <div class="mission-card">
+                    <h3>Visión</h3>
+                    <p>Ser el ecosistema tecnológico de referencia en el norte del Perú, integrando laboratorio, retail y soporte corporativo con innovación constante y experiencias memorables.</p>
+                </div>
+                <div class="mission-card">
+                    <h3>Valores</h3>
+                    <ul>
+                        <li><strong>Confianza:</strong> Comunicación clara, garantías reales.</li>
+                        <li><strong>Innovación:</strong> Capacitación constante y equipos de vanguardia.</li>
+                        <li><strong>Calidez:</strong> Trato personalizado y seguimiento cercano.</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section class="about-numbers">
+            <div class="container about-numbers__grid">
+                <div class="about-number">
+                    <strong>+25k</strong>
+                    <span>Equipos reparados con evidencia audiovisual.</span>
+                </div>
+                <div class="about-number">
+                    <strong>+4k</strong>
+                    <span>Accesorios entregados listos para regalar o revender.</span>
+                </div>
+                <div class="about-number">
+                    <strong>99%</strong>
+                    <span>De clientes recomiendan nuestro servicio a familiares y amigos.</span>
+                </div>
+            </div>
+        </section>
+
+        <section class="team-section">
+            <div class="container team-section__grid">
+                <div class="team-section__content">
+                    <h2>El equipo detrás de cada historia de éxito.</h2>
+                    <p>Somos técnicos, asesores y creativos que disfrutan lo que hacen. Nos encanta explicar cada paso, compartir tips de cuidado y estar disponibles cuando más nos necesitas.</p>
+                    <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20trabajar%20con%20ustedes." target="_blank" class="button button-outline">Quiero unirme al equipo</a>
+                </div>
+                <div class="team-section__media">
+                    <img src="assets/images/tecnico-reparando-telefono.png" alt="Técnico iPro Perú trabajando">
+                </div>
+            </div>
+        </section>
+
+        <section class="cta-final">
+            <div class="container cta-final__content">
+                <div class="cta-final__text">
+                    <h2>Visítanos y vive la experiencia iPro Perú.</h2>
+                    <p>Estamos en Av. Loreto 336, Piura. Agenda tu cita o llega directo, siempre habrá alguien listo para ayudarte.</p>
+                </div>
+                <div class="cta-final__actions">
+                    <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20agendar%20una%20cita." target="_blank" class="button button-primary"><i class="fab fa-whatsapp"></i> Agendar visita</a>
+                    <a href="https://www.google.com/maps?q=-5.191405,-80.6284335" target="_blank" class="button button-ghost"><i class="fa-solid fa-location-dot"></i> Cómo llegar</a>
+                </div>
+            </div>
+        </section>
+
     </main>
 
     <div id="footer-placeholder"></div>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,16 +1,19 @@
 <footer class="main-footer">
     <div class="container footer-grid">
         <div class="footer-column">
-            <h4 class="footer-heading">Horario de Atención</h4>
-            <p>Lunes a Domingo</p>
-            <p>8:30 am - 9:00 pm</p>
-        </div>
-        <div class="footer-column">
-            <h4 class="footer-heading">Encuéntranos</h4>
+            <h4 class="footer-heading">Visítanos</h4>
             <p>Av. Loreto 336, Piura, Perú</p>
+            <p>Showroom y laboratorio express</p>
             <a href="https://www.google.com/maps?q=-5.191405,-80.6284335" target="_blank" class="footer-link">
                 Cómo llegar con Google Maps
             </a>
+        </div>
+        <div class="footer-column">
+            <h4 class="footer-heading">Horario de Atención</h4>
+            <p>Lunes a Domingo</p>
+            <p>8:30 am - 9:00 pm</p>
+            <a href="tel:+51979012180" class="footer-link"><i class="fa-solid fa-phone"></i> 979&nbsp;012&nbsp;180</a>
+            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20vengo%20del%20sitio%20web." target="_blank" class="footer-link"><i class="fab fa-whatsapp"></i> Escríbenos ahora</a>
         </div>
         <div class="footer-column">
             <h4 class="footer-heading">Síguenos</h4>
@@ -20,6 +23,9 @@
                 </a>
                 <a href="https://www.instagram.com/ipro.peru/" target="_blank" class="social-link">
                     <i class="fab fa-instagram"></i> Instagram
+                </a>
+                <a href="https://www.facebook.com/iproperu" target="_blank" class="social-link">
+                    <i class="fab fa-facebook"></i> Facebook
                 </a>
             </div>
         </div>

--- a/productos.html
+++ b/productos.html
@@ -14,14 +14,68 @@
     <div id="header-placeholder"></div>
 
     <main>
-        <section class="page-banner" style="background-image: url('https://images.unsplash.com/photo-1592759963028-c51d65839589?q=80&w=2670&auto=format&fit=crop');">
-            <div class="container">
-                <h1 class="banner-title">Nuestros Equipos</h1>
-                <p class="banner-subtitle">Calidad y garantía en cada dispositivo.</p>
+        <section class="products-hero">
+            <div class="container products-hero__grid">
+                <div class="products-hero__content">
+                    <span class="products-hero__kicker">Catálogo iPro Perú</span>
+                    <h1>Equipos y accesorios premium listos para entregar hoy.</h1>
+                    <p>Desde el iPhone más deseado hasta el cargador ideal para tu día a día. Garantía escrita, activación personalizada y delivery en Piura.</p>
+                    <div class="products-hero__actions">
+                        <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20comprar%20un%20equipo." target="_blank" class="button button-primary"><i class="fab fa-whatsapp"></i> Hablar con ventas</a>
+                        <a href="#catalogo" class="button button-outline">Ver catálogo completo</a>
+                    </div>
+                    <ul class="products-hero__benefits">
+                        <li><i class="fa-solid fa-shield-check"></i> Garantía hasta por 12 meses.</li>
+                        <li><i class="fa-solid fa-box"></i> Entrega inmediata y opciones de delivery.</li>
+                        <li><i class="fa-solid fa-repeat"></i> Recibimos tu equipo en parte de pago.</li>
+                    </ul>
+                </div>
+                <div class="products-hero__media">
+                    <img src="assets/images/telefonos.png" alt="Colección de smartphones iPro Perú">
+                    <div class="products-hero__badge">
+                        <strong>Stock actualizado</strong>
+                        <span>Cada semana en showroom y online</span>
+                    </div>
+                </div>
             </div>
         </section>
 
-        <section class="products-catalog">
+        <section class="category-showcase">
+            <div class="container">
+                <div class="section-heading">
+                    <h2 class="section-title">Encuentra tu siguiente adquisición</h2>
+                    <p class="section-subtitle">Seleccionamos productos irresistibles para personas, empresas y creadores de contenido.</p>
+                </div>
+                <div class="category-grid">
+                    <article class="category-card">
+                        <img src="assets/images/iphone-promax-15.webp" alt="iPhone premium" class="category-card__media">
+                        <div class="category-card__body">
+                            <h3>iPhone nuevos y reacondicionados</h3>
+                            <p>Modelos desde el iPhone 11 hasta el último lanzamiento. Incluye migración de datos y accesorios de regalo.</p>
+                            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20informaci%C3%B3n%20de%20iPhone." target="_blank" class="service-link service-link--accent">Cotizar iPhone</a>
+                        </div>
+                    </article>
+                    <article class="category-card">
+                        <img src="assets/images/iphone-honor-presentación-hero.png" alt="Smartphones Android" class="category-card__media">
+                        <div class="category-card__body">
+                            <h3>Android gama alta y media</h3>
+                            <p>HONOR, Samsung, Xiaomi y más marcas listas para trabajar, crear contenido y jugar sin límites.</p>
+                            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20busco%20un%20Android%20potente." target="_blank" class="service-link service-link--accent">Solicitar asesor</a>
+                        </div>
+                    </article>
+                    <article class="category-card">
+                        <img src="assets/images/producto-supercargadores-portatiles.webp" alt="Accesorios tecnológicos" class="category-card__media">
+                        <div class="category-card__body">
+                            <h3>Accesorios que marcan la diferencia</h3>
+                            <p>Cargadores originales, powerbanks, audio temático y cases personalizados para proteger con estilo.</p>
+                            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20accesorios%20para%20mi%20equipo." target="_blank" class="service-link service-link--accent">Ver combos</a>
+                        </div>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="products-catalog" id="catalogo">
             <div class="container">
                 <div class="product-filters">
                     <button class="filter-btn active" data-filter="all">Todos</button>
@@ -30,50 +84,98 @@
                     <button class="filter-btn" data-filter="accesorios">Accesorios</button>
                 </div>
 
-                <div class="products-grid">
+                <div class="products-grid catalog-grid">
                     <div class="product-card" data-category="iphone">
                         <img src="assets/images/iphone-promax-15.webp" alt="iPhone 15 Pro Max">
                         <div class="product-info">
                             <h3 class="product-name">iPhone 15 Pro Max</h3>
-                            <p class="product-spec">256GB - Titanio Natural</p>
-                            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola,%20quisiera%20consultar%20por%20el%20iPhone%2015%20Pro%20Max." target="_blank" class="product-cta">
-                                <i class="fab fa-whatsapp"></i> Consultar por WhatsApp
+                            <p class="product-spec">256GB · Titanio Natural · Incluye AppleCare opcional</p>
+                            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20el%20iPhone%2015%20Pro%20Max." target="_blank" class="product-cta">
+                                <i class="fab fa-whatsapp"></i> Separar unidad
+                            </a>
+                        </div>
+                    </div>
+
+                    <div class="product-card" data-category="iphone">
+                        <img src="assets/images/Producto-iphone-venta.webp" alt="iPhone 13">
+                        <div class="product-info">
+                            <h3 class="product-name">iPhone 13</h3>
+                            <p class="product-spec">128GB · Colores disponibles · Garantía 12 meses</p>
+                            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20saber%20del%20iPhone%2013." target="_blank" class="product-cta">
+                                <i class="fab fa-whatsapp"></i> Consultar stock
                             </a>
                         </div>
                     </div>
 
                     <div class="product-card" data-category="android">
-                        <img src="https://images.unsplash.com/photo-1698228308823-2748a1a36423?q=80&w=2564&auto=format&fit=crop" alt="Samsung Galaxy S24 Ultra">
+                        <img src="assets/images/iphone-honor-presentación-hero.png" alt="HONOR y otros Android">
                         <div class="product-info">
-                            <h3 class="product-name">Samsung Galaxy S24 Ultra</h3>
-                            <p class="product-spec">512GB - Negro Titanio</p>
-                            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola,%20quisiera%20consultar%20por%20el%20Samsung%20Galaxy%20S24%20Ultra." target="_blank" class="product-cta">
-                                <i class="fab fa-whatsapp"></i> Consultar por WhatsApp
+                            <h3 class="product-name">HONOR Magic &amp; aliados</h3>
+                            <p class="product-spec">Pantallas OLED 120Hz · Cámaras Pro · Packs corporativos</p>
+                            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20un%20smartphone%20HONOR." target="_blank" class="product-cta">
+                                <i class="fab fa-whatsapp"></i> Hablar con asesor
+                            </a>
+                        </div>
+                    </div>
+
+                    <div class="product-card" data-category="accesorios" id="baterias">
+                        <img src="assets/images/bateria-iphone-voltrax.webp" alt="Batería Voltrax para iPhone">
+                        <div class="product-info">
+                            <h3 class="product-name">Baterías Voltrax y OEM</h3>
+                            <p class="product-spec">Compatibles con iPhone y Android · Instalación en laboratorio</p>
+                            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20una%20bater%C3%ADa%20Voltrax." target="_blank" class="product-cta">
+                                <i class="fab fa-whatsapp"></i> Cotizar instalación
                             </a>
                         </div>
                     </div>
 
                     <div class="product-card" data-category="accesorios">
-                        <img src="https://images.unsplash.com/photo-1550188047-2f3a74de59a8?q=80&w=2670&auto=format&fit=crop" alt="AirPods Pro">
+                        <img src="assets/images/producto-cargador-iphone (2).webp" alt="Cargador rápido para iPhone">
                         <div class="product-info">
-                            <h3 class="product-name">AirPods Pro 2da Gen</h3>
-                            <p class="product-spec">Estuche de carga MagSafe (USB-C)</p>
-                             <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola,%20quisiera%20consultar%20por%20los%20AirPods%20Pro." target="_blank" class="product-cta">
-                                <i class="fab fa-whatsapp"></i> Consultar por WhatsApp
+                            <h3 class="product-name">Cargadores rápidos</h3>
+                            <p class="product-spec">USB-C, MagSafe y adaptadores de alta potencia certificados</p>
+                            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20busco%20cargadores%20r%C3%A1pidos." target="_blank" class="product-cta">
+                                <i class="fab fa-whatsapp"></i> Armar combo</a>
+                        </div>
+                    </div>
+
+                    <div class="product-card" data-category="accesorios">
+                        <img src="assets/images/Altavoces-de-sonido-tematica-transformes.webp" alt="Altavoces temáticos Transformers">
+                        <div class="product-info">
+                            <h3 class="product-name">Altavoces edición Transformers</h3>
+                            <p class="product-spec">Luces RGB · Bluetooth · Batería de larga duración</p>
+                            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20los%20altavoces%20tem%C3%A1ticos." target="_blank" class="product-cta">
+                                <i class="fab fa-whatsapp"></i> Solicitar demo
                             </a>
                         </div>
                     </div>
-                    
-                    <div class="product-card" data-category="iphone">
-                        <img src="https://images.unsplash.com/photo-1678922572539-7887e5a408b4?q=80&w=2574&auto=format&fit=crop" alt="iPhone 14">
+
+                    <div class="product-card" data-category="accesorios">
+                        <img src="assets/images/cajas-de-audifono-inalambricos-tematicos.webp" alt="Audífonos inalámbricos temáticos">
                         <div class="product-info">
-                            <h3 class="product-name">iPhone 14</h3>
-                            <p class="product-spec">128GB - Color Medianoche</p>
-                            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola,%20quisiera%20consultar%20por%20el%20iPhone%2014." target="_blank" class="product-cta">
-                                <i class="fab fa-whatsapp"></i> Consultar por WhatsApp
+                            <h3 class="product-name">Audífonos inalámbricos temáticos</h3>
+                            <p class="product-spec">Estuches coleccionables · Cancelación de ruido · Ediciones limitadas</p>
+                            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20aud%C3%ADfonos%20tem%C3%A1ticos." target="_blank" class="product-cta">
+                                <i class="fab fa-whatsapp"></i> Pedir catálogo
                             </a>
                         </div>
                     </div>
+
+                    <div class="product-card" data-category="accesorios">
+                        <img src="assets/images/producto-cabeza-de-cargador.webp" alt="Cabezal de cargador premium">
+                        <div class="product-info">
+                            <h3 class="product-name">Adaptadores y hubs</h3>
+                            <p class="product-spec">Soluciones de carga múltiple para hogares, negocios y autos</p>
+                            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20necesito%20adaptadores." target="_blank" class="product-cta">
+                                <i class="fab fa-whatsapp"></i> Cotizar ahora
+                            </a>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="products-cta">
+                    <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20recibir%20la%20lista%20completa%20de%20productos." target="_blank" class="button button-primary">Quiero la lista completa</a>
+                    <a href="tel:+51979012180" class="button button-ghost"><i class="fa-solid fa-phone"></i> 979&nbsp;012&nbsp;180</a>
                 </div>
             </div>
         </section>

--- a/servicios.html
+++ b/servicios.html
@@ -13,10 +13,50 @@
     <div id="header-placeholder"></div>
 
     <main>
-        <section class="page-banner" style="background-image: url('https://images.unsplash.com/photo-1576021182235-ea1d7b365858?q=80&w=2670&auto=format&fit=crop');">
-            <div class="container">
-                <h1 class="banner-title">SOLUCIONA TU PROBLEMA</h1>
-                <p class="banner-subtitle">Selecciona el tipo de problema que presenta tu equipo.</p>
+        <section class="service-hero">
+            <div class="container service-hero__grid">
+                <div class="service-hero__content">
+                    <span class="service-hero__kicker">Servicio Técnico Premium</span>
+                    <h1>Solucionamos tu urgencia móvil con repuestos garantizados.</h1>
+                    <p>Diagnóstico inmediato, repuestos originales y seguimiento por WhatsApp desde que ingresas tu equipo. Somos el laboratorio especializado en iPhone y Android preferido por los piuranos.</p>
+                    <div class="service-hero__cta">
+                        <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20necesito%20soporte%20t%C3%A9cnico." target="_blank" class="button button-primary"><i class="fab fa-whatsapp"></i> Escríbenos ahora</a>
+                        <a href="#service-categories" class="button button-outline">Ver categorías de servicio</a>
+                    </div>
+                    <ul class="service-hero__highlights">
+                        <li><i class="fa-solid fa-stopwatch"></i> Reparaciones express desde 20 minutos.</li>
+                        <li><i class="fa-solid fa-shield"></i> Garantía escrita y factura electrónica.</li>
+                        <li><i class="fa-solid fa-video"></i> Evidencia en video del proceso de reparación.</li>
+                    </ul>
+                </div>
+                <div class="service-hero__media">
+                    <img src="assets/images/tecnico-reparando-telefono.png" alt="Técnico de iPro Perú reparando un teléfono">
+                    <div class="service-hero__badge">
+                        <strong>+25 000</strong>
+                        <span>Equipos intervenidos con éxito</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="service-intro" id="service-categories">
+            <div class="container service-intro__grid">
+                <div class="service-intro__copy">
+                    <h2>Todo lo que necesita tu smartphone, en un solo lugar.</h2>
+                    <p>Elige la categoría que describe tu falla, descubre qué incluye el servicio y agenda tu cita sin complicaciones. Si no encuentras tu caso, cuéntanos por WhatsApp y te guiamos.</p>
+                </div>
+                <div class="service-intro__guarantees">
+                    <div class="guarantee-card">
+                        <i class="fa-solid fa-user-check"></i>
+                        <h3>Técnicos certificados</h3>
+                        <p>Capacitación constante en laboratorios internacionales.</p>
+                    </div>
+                    <div class="guarantee-card">
+                        <i class="fa-solid fa-screwdriver-wrench"></i>
+                        <h3>Repuestos premium</h3>
+                        <p>Piezas OEM, originales y marcas aliadas como Voltrax.</p>
+                    </div>
+                </div>
             </div>
         </section>
 
@@ -36,6 +76,54 @@
         </section>
 
         <section id="service-details-container" class="container"></section>
+
+        <section class="service-process">
+            <div class="container">
+                <div class="section-heading">
+                    <h2 class="section-title">Así cuidamos tu equipo en iPro Perú</h2>
+                    <p class="section-subtitle">Un flujo transparente, rápido y sin sorpresas en el presupuesto.</p>
+                </div>
+                <div class="process-grid">
+                    <div class="process-card">
+                        <span class="process-number">1</span>
+                        <h3>Diagnóstico inmediato</h3>
+                        <p>Revisamos tu equipo frente a ti y registramos el estado en video para mayor confianza.</p>
+                    </div>
+                    <div class="process-card">
+                        <span class="process-number">2</span>
+                        <h3>Cotización transparente</h3>
+                        <p>Te explicamos opciones de repuestos y tiempos estimados antes de iniciar la reparación.</p>
+                    </div>
+                    <div class="process-card">
+                        <span class="process-number">3</span>
+                        <h3>Reparación certificada</h3>
+                        <p>Trabajamos en laboratorio antiestático, con herramientas calibradas y repuestos premium.</p>
+                    </div>
+                    <div class="process-card">
+                        <span class="process-number">4</span>
+                        <h3>Entrega y garantía</h3>
+                        <p>Probamos contigo, entregamos garantía escrita y mantenemos soporte post servicio.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="service-trust">
+            <div class="container service-trust__grid">
+                <div class="service-trust__copy">
+                    <h2>Clientes felices que regresan y recomiendan.</h2>
+                    <p>Más del 70% de nuestras atenciones llegan por recomendación. Somos proveedores de empresas, emprendedores, creadores de contenido y familias que necesitan un aliado tecnológico permanente.</p>
+                    <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20programar%20un%20servicio%20t%C3%A9cnico." target="_blank" class="button button-primary">Quiero mi cotización</a>
+                </div>
+                <div class="service-trust__media">
+                    <img src="assets/images/Pantalla-reparada-hero.png" alt="Teléfono reparado por iPro Perú">
+                    <div class="service-trust__quote">
+                        “Los únicos que me dieron solución el mismo día y me mandaron videos del proceso. Totalmente recomendados.”
+                        <span>— José Luis A., gamer y creador de contenido</span>
+                    </div>
+                </div>
+            </div>
+        </section>
     </main>
     
     <div id="whatsapp-modal" class="modal-overlay">
@@ -53,39 +141,39 @@
     <div id="footer-placeholder"></div>
 
     <template id="template-pantallas">
-        <div class="service-detail-content">
-            <h2>Problemas Comunes de Pantalla</h2>
-            <p>Cada problema tiene una solución específica. Encuentra el tuyo a continuación.</p>
+        <div id="detail-pantallas" class="service-detail-content">
+            <h2>Problemas frecuentes de pantallas</h2>
+            <p>Trabajamos con pantallas OLED, LCD y originales según tu modelo. Si no ves tu caso escríbenos y te asesoramos.</p>
             <div class="masonry-grid">
                 <div class="masonry-item">
-                    <img src="assets/images/Cristal-roto.jpeg" alt="Teléfono con el cristal de la pantalla roto">
+                    <img src="assets/images/Pantalla-rota-antes-despues.webp" alt="Pantalla con cristal roto antes y después">
                     <div class="masonry-item-content">
-                        <h4>Cristal Roto (Táctil OK)</h4>
-                        <p class="problem-desc">La solución ideal y más económica si solo se dañó el vidrio exterior de tu equipo.</p>
+                        <h4>Vidrio roto, táctil funcional</h4>
+                        <p class="problem-desc">Reemplazamos solo el cristal para mantener tu panel original y ahorrar presupuesto.</p>
                         <div class="problem-actions">
-                            <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola,%20tengo%20el%20cristal%20de%20la%20pantalla%20roto.">Cotizar Ahora</button>
+                            <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20tengo%20el%20vidrio%20de%20mi%20pantalla%20roto.">Cotizar ahora</button>
                             <a href="/servicios/pantalla-cristal-roto.html" class="link-saber-mas">Saber más...</a>
                         </div>
                     </div>
                 </div>
                 <div class="masonry-item">
-                    <img src="https://images.unsplash.com/photo-1550009158-94ae76252426?q=80&w=2574&auto=format&fit=crop" alt="Teléfono con líneas de colores en la pantalla">
+                    <img src="assets/images/Pantalla-reparada-hero.png" alt="Pantalla con manchas reparada">
                     <div class="masonry-item-content">
-                        <h4>Pantalla con Manchas o Líneas</h4>
-                        <p class="problem-desc">Indica un daño en el panel LCD/OLED interno. Requiere un cambio de pantalla completo.</p>
+                        <h4>Manchas, líneas o imagen negra</h4>
+                        <p class="problem-desc">Cambio completo del módulo OLED/LCD con garantía de brillo y color.</p>
                         <div class="problem-actions">
-                            <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola,%20mi%20pantalla%20tiene%20manchas%20o%20líneas.">Cotizar Ahora</button>
+                            <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20mi%20pantalla%20tiene%20manchas%20o%20l%C3%ADneas.">Quiero mi cotización</button>
                             <a href="/servicios/pantalla-manchas-lineas.html" class="link-saber-mas">Saber más...</a>
                         </div>
                     </div>
                 </div>
                 <div class="masonry-item">
-                    <img src="https://images.unsplash.com/photo-1628292433072-f673f3a5a4a4?q=80&w=2532&auto=format&fit=crop" alt="Mano tocando una pantalla de teléfono que no responde">
+                    <img src="assets/images/tecnico-reparando-telefono.png" alt="Técnico reparando táctil de smartphone">
                     <div class="masonry-item-content">
-                        <h4>Táctil no Funciona</h4>
-                        <p class="problem-desc">Si tu pantalla no responde o se presiona sola, solucionamos los fallos del digitalizador.</p>
+                        <h4>Táctil sin respuesta</h4>
+                        <p class="problem-desc">Calibramos o reemplazamos el digitalizador para que vuelvas a deslizar sin esfuerzo.</p>
                         <div class="problem-actions">
-                            <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola,%20el%20táctil%20de%20mi%20pantalla%20no%20funciona.">Cotizar Ahora</button>
+                            <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20mi%20pantalla%20no%20responde.%20Ayuda.">Agendar revisión</button>
                             <a href="/servicios/pantalla-tactil-falla.html" class="link-saber-mas">Saber más...</a>
                         </div>
                     </div>
@@ -95,29 +183,27 @@
     </template>
 
     <template id="template-bateria">
-        <div class="service-detail-content">
-            <h2>Problemas Comunes de Batería</h2>
-            <p>Recupera la autonomía y seguridad de tu equipo con nuestros servicios de batería.</p>
+        <div id="detail-bateria" class="service-detail-content">
+            <h2>Recupera la energía de tu equipo</h2>
+            <p>Instalamos baterías originales y Voltrax con control de calidad. Incluye diagnóstico de carga y reporte de salud.</p>
             <div class="masonry-grid">
                 <div class="masonry-item">
-                    <img src="https://images.unsplash.com/photo-1610438235354-a1ae3a640134?q=80&w=2670&auto=format&fit=crop" alt="Teléfono conectado a un cargador">
+                    <img src="assets/images/bateria-iphone-voltrax.webp" alt="Batería Voltrax">
                     <div class="masonry-item-content">
-                        <h4>Se Descarga Rápido</h4>
-                        <p class="problem-desc">El problema más común. Reemplazamos tu batería agotada en minutos por una certificada.</p>
+                        <h4>Se descarga rápido</h4>
+                        <p class="problem-desc">Cambio express de batería con calibración y optimización de software.</p>
                         <div class="problem-actions">
-                            <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola,%20la%20batería%20de%20mi%20equipo%20se%20descarga%20rápido.">Cotizar Ahora</button>
-                            <a href="/servicios/bateria-descarga-rapido.html" class="link-saber-mas">Saber más...</a>
+                            <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20mi%20bater%C3%ADa%20se%20descarga%20muy%20r%C3%A1pido.">Cambiar batería</button>
                         </div>
                     </div>
                 </div>
                 <div class="masonry-item">
-                    <img src="https://images.unsplash.com/photo-1596043513325-218d6e57513b?q=80&w=2670&auto=format&fit=crop" alt="Teléfono con la tapa trasera levantada mostrando una batería hinchada">
+                    <img src="assets/images/Bateria-producto.webp" alt="Varias baterías en stock">
                     <div class="masonry-item-content">
-                        <h4>Batería Hinchada</h4>
-                        <p class="problem-desc">Un riesgo de seguridad. Retiramos y reemplazamos la batería dañada de forma segura.</p>
+                        <h4>Batería hinchada o dañada</h4>
+                        <p class="problem-desc">Retiro seguro, limpieza del compartimento y reemplazo con repuesto certificado.</p>
                         <div class="problem-actions">
-                            <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola,%20creo%20que%20la%20batería%20de%20mi%20equipo%20está%20hinchada.">Cotizar Ahora</button>
-                            <a href="/servicios/bateria-hinchada.html" class="link-saber-mas">Saber más...</a>
+                            <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20mi%20bater%C3%ADa%20est%C3%A1%20hinchada.">Necesito ayuda</button>
                         </div>
                     </div>
                 </div>
@@ -126,23 +212,24 @@
     </template>
 
     <template id="template-carga">
-        <div class="service-detail-content">
-            <h2>Problemas de Carga y Energía</h2>
+        <div id="detail-carga" class="service-detail-content">
+            <h2>Problemas de carga y energía</h2>
+            <p>Desde adaptadores certificados hasta reparaciones de placa. Evaluamos todo el circuito de energía.</p>
             <div class="masonry-grid">
                 <div class="masonry-item">
-                    <img src="https://images.unsplash.com/photo-1624558474937-3b04ca8b610a?q=80&auto=format&fit=crop" alt="Puerto de carga dañado">
+                    <img src="assets/images/producto-cargador-iphone (1).webp" alt="Cargador para iPhone en caja">
                     <div class="masonry-item-content">
-                        <h4>Cambio de Pin de Carga</h4>
-                        <p class="problem-desc">Si tu equipo no carga o tienes que mover el cable, esta es la solución.</p>
-                        <button class="cta-button-service" data-whatsapp-link="URL_WSP">Cotizar Ahora</button>
+                        <h4>Cambio de pin o puerto</h4>
+                        <p class="problem-desc">Si debes mover el cable o ya no carga, reemplazamos el conector con soldadura de precisión.</p>
+                        <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20mi%20puerto%20de%20carga%20fall%C3%B3.">Cotizar reparación</button>
                     </div>
                 </div>
                 <div class="masonry-item">
-                    <img src="https://images.unsplash.com/photo-1605334237189-8a3e792c3b28?q=80&auto=format&fit=crop" alt="Equipo que no enciende">
+                    <img src="assets/images/producto-cabeza-de-cargador.webp" alt="Cabezal de cargador premium">
                     <div class="masonry-item-content">
-                        <h4>Equipo no Enciende</h4>
-                        <p class="problem-desc">Diagnóstico profesional para fallas de encendido relacionadas a la placa o batería.</p>
-                        <button class="cta-button-service" data-whatsapp-link="URL_WSP">Diagnosticar</button>
+                        <h4>Equipos que no encienden</h4>
+                        <p class="problem-desc">Diagnóstico de placa y reemplazo de componentes dañados. Incluye reporte técnico.</p>
+                        <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20mi%20tel%C3%A9fono%20no%20enciende.">Solicitar diagnóstico</button>
                     </div>
                 </div>
             </div>
@@ -150,48 +237,124 @@
     </template>
 
     <template id="template-camaras">
-    <div class="service-detail-content">
-        <h2>Problemas de Cámara y Video del Celular</h2>
-        <p>Solucionamos fallas de enfoque, imagen negra, cristal de lente roto y errores en la grabación de video.</p>
-        <div class="masonry-grid">
-            <div class="masonry-item">
-                <img src="https://images.unsplash.com/photo-1596594720934-5d519b6e8a8d?q=80&auto=format&fit=crop" alt="Lente de cámara de celular rota">
-                <div class="masonry-item-content">
-                    <h4>Cambio de Cristal de Lente</h4>
-                    <p class="problem-desc">Si se rompió solo el vidrio que protege tu lente, lo cambiamos para que tus fotos vuelvan a ser nítidas.</p>
-                    <button class="cta-button-service" data-whatsapp-link="URL_WSP">Cotizar Cristal</button>
-                </div>
-            </div>
-            <div class="masonry-item">
-                <img src="https://images.unsplash.com/photo-1616077168079-7e09a677fb2c?q=80&auto=format&fit=crop" alt="Cámara de celular con imagen en negro">
-                <div class="masonry-item-content">
-                    <h4>Falla de Cámara (Imagen Negra)</h4>
-                    <p class="problem-desc">Si la app de cámara muestra una imagen negra, no enfoca o se cierra, requiere un reemplazo del módulo.</p>
-                    <button class="cta-button-service" data-whatsapp-link="URL_WSP">Cotizar Módulo</button>
-                </div>
-            </div>
-        </div>
-    </div>
-</template>
-    
-    <template id="template-audio">
-        <div class="service-detail-content">
-            <h2>Problemas de Audio</h2>
+        <div id="detail-camaras" class="service-detail-content">
+            <h2>Cámara y video impecables</h2>
+            <p>Reparamos tanto las cámaras frontales como traseras, calibrando el software para que vuelvas a crear contenido sin fallas.</p>
             <div class="masonry-grid">
                 <div class="masonry-item">
-                    <img src="https://images.unsplash.com/photo-1589254066205-d0886120234c?q=80&auto=format&fit=crop" alt="Auricular de llamadas de un celular">
+                    <img src="assets/images/cambio-de-camara.webp" alt="Módulo de cámaras de smartphone">
                     <div class="masonry-item-content">
-                        <h4>Cambio de Auricular Interno</h4>
-                        <p class="problem-desc">Si no escuchas bien durante las llamadas, limpiamos o reemplazamos el auricular superior.</p>
-                        <button class="cta-button-service" data-whatsapp-link="URL_WSP">Cotizar Reparación</button>
+                        <h4>Cristal protector roto</h4>
+                        <p class="problem-desc">Sustituimos el cristal sin afectar el módulo interno para mantener la nitidez.</p>
+                        <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20se%20rompi%C3%B3%20el%20cristal%20de%20mi%20c%C3%A1mara.">Cambiar cristal</button>
                     </div>
                 </div>
                 <div class="masonry-item">
-                    <img src="https://images.unsplash.com/photo-1618384887924-c9989e15091a?q=80&auto=format&fit=crop" alt="Altavoz de un celular">
+                    <img src="assets/images/Producto-iphone-venta.webp" alt="iPhone enfocado">
                     <div class="masonry-item-content">
-                        <h4>Reparación de Altavoz</h4>
-                        <p class="problem-desc">Solucionamos problemas de sonido bajo, distorsionado o nulo al reproducir música o videos.</p>
-                        <button class="cta-button-service" data-whatsapp-link="URL_WSP">Cotizar Altavoz</button>
+                        <h4>Imagen negra o fuera de foco</h4>
+                        <p class="problem-desc">Reemplazamos el módulo completo y recalibramos el sistema para restaurar el enfoque.</p>
+                        <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20mi%20c%C3%A1mara%20sale%20negra.">Cotizar módulo</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </template>
+
+    <template id="template-audio">
+        <div id="detail-audio" class="service-detail-content">
+            <h2>Servicios de audio</h2>
+            <p>Solucionamos fallas de altavoz, micrófonos y auriculares internos para que escuches cada detalle.</p>
+            <div class="masonry-grid">
+                <div class="masonry-item">
+                    <img src="assets/images/cajas-de-audifono-inalambricos-tematicos.webp" alt="Audífonos inalámbricos temáticos">
+                    <div class="masonry-item-content">
+                        <h4>Auricular interno bajo</h4>
+                        <p class="problem-desc">Limpieza profunda o reemplazo para que tus llamadas vuelvan a escucharse claras.</p>
+                        <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20no%20escucho%20mis%20llamadas.">Agendar servicio</button>
+                    </div>
+                </div>
+                <div class="masonry-item">
+                    <img src="assets/images/Altavoces-de-sonido-tematica-transformes.webp" alt="Altavoces temáticos">
+                    <div class="masonry-item-content">
+                        <h4>Altavoz distorsionado</h4>
+                        <p class="problem-desc">Reemplazo de parlantes y limpieza de mallas para recuperar el sonido original.</p>
+                        <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20mi%20altavoz%20suena%20mal.">Cotizar reparación</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </template>
+
+    <template id="template-software">
+        <div id="detail-software" class="service-detail-content">
+            <h2>Software y sistema</h2>
+            <p>Optimizamos tu smartphone con actualizaciones, reinstalaciones limpias y configuración de seguridad.</p>
+            <div class="masonry-grid">
+                <div class="masonry-item">
+                    <img src="assets/images/telefonos.png" alt="Teléfonos actualizando software">
+                    <div class="masonry-item-content">
+                        <h4>Actualización y reinstalación</h4>
+                        <p class="problem-desc">Recuperamos el rendimiento corrigiendo errores de sistema, bloqueos y restableciendo apps.</p>
+                        <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20necesito%20ayuda%20con%20el%20software%20de%20mi%20equipo.">Agendar soporte</button>
+                    </div>
+                </div>
+                <div class="masonry-item">
+                    <img src="assets/images/iphone-promax-15.webp" alt="iPhone configurándose">
+                    <div class="masonry-item-content">
+                        <h4>Optimización para empresas</h4>
+                        <p class="problem-desc">Configuramos múltiples equipos, gestión de MDM, copias de seguridad y migración de datos.</p>
+                        <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20optimizar%20el%20software%20de%20mi%20equipo.">Solicitar propuesta</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </template>
+
+    <template id="template-conectividad">
+        <div id="detail-conectividad" class="service-detail-content">
+            <h2>Reparación de conectividad</h2>
+            <p>¿Se va la señal o el WiFi? Revisamos antenas, flex y configuraciones para mantenerte siempre conectado.</p>
+            <div class="masonry-grid">
+                <div class="masonry-item">
+                    <img src="assets/images/iphone-honor-presentación-hero.png" alt="Smartphones con señal completa">
+                    <div class="masonry-item-content">
+                        <h4>Problemas de señal o datos</h4>
+                        <p class="problem-desc">Reemplazo de antenas, flex y módulos de comunicación. Incluye pruebas de campo.</p>
+                        <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20mi%20tel%C3%A9fono%20pierde%20se%C3%B1al.">Cotizar servicio</button>
+                    </div>
+                </div>
+                <div class="masonry-item">
+                    <img src="assets/images/producto-supercargadores-portatiles.webp" alt="Dispositivos conectados">
+                    <div class="masonry-item-content">
+                        <h4>Bluetooth &amp; WiFi inestable</h4>
+                        <p class="problem-desc">Limpieza, calibración y reemplazo de módulos de conectividad para accesorios y redes.</p>
+                        <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20mi%20bluetooth%20no%20funciona%20bien.">Revisar equipo</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </template>
+
+    <template id="template-general">
+        <div id="detail-general" class="service-detail-content">
+            <h2>Diagnóstico integral</h2>
+            <p>No estás seguro de la falla? Trae tu equipo y hacemos un chequeo completo con presupuesto al instante.</p>
+            <div class="masonry-grid">
+                <div class="masonry-item">
+                    <img src="assets/images/tecnico-reparando-telefono.png" alt="Diagnóstico de smartphone">
+                    <div class="masonry-item-content">
+                        <h4>Daño por líquido o golpe</h4>
+                        <p class="problem-desc">Rescate de placa, limpieza ultrasónica y reemplazo de componentes críticos.</p>
+                        <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20mi%20equipo%20tuvo%20un%20accidente.">Quiero diagnóstico</button>
+                    </div>
+                </div>
+                <div class="masonry-item">
+                    <img src="assets/images/personal.png" alt="Equipo técnico de iPro Perú">
+                    <div class="masonry-item-content">
+                        <h4>Planes para empresas</h4>
+                        <p class="problem-desc">Mantenimiento preventivo, reposición de flotas y soporte prioritario para tu negocio.</p>
+                        <button class="cta-button-service" data-whatsapp-link="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20un%20plan%20corporativo.">Solicitar asesor</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- render the first service detail automatically on load without jumping the page
- reuse a shared renderer for hash navigation and prevent duplicate modal bindings
- allow closing the WhatsApp modal from the overlay/Escape key and guard the continue link

## Testing
- No automated tests (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc3fa5bcc08321b94722d3695ec580