### PR TITLE
Replace product thumbnails with interactive videos

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1445,6 +1445,8 @@ section {
     text-align: left;
     box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
     transition: transform var(--transition-speed), box-shadow var(--transition-speed);
+    display: flex;
+    flex-direction: column;
 }
 
 .product-card:hover {
@@ -1452,10 +1454,74 @@ section {
     box-shadow: 0 24px 55px rgba(15, 23, 42, 0.16);
 }
 
-.product-card img {
+.product-media {
+    position: relative;
+    aspect-ratio: 9 / 16;
+    background: #000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    flex-shrink: 0;
+}
+
+.product-card:hover .product-media,
+.product-card:focus-within .product-media {
+    filter: brightness(1.05);
+}
+
+.product-video {
     width: 100%;
-    height: 220px;
+    height: 100%;
     object-fit: cover;
+    background: #000;
+}
+
+.product-media[data-letterboxed="true"] .product-video {
+    object-fit: contain;
+    background: radial-gradient(circle, rgba(15, 23, 42, 0.35) 0%, rgba(15, 23, 42, 0.7) 100%);
+}
+
+.audio-toggle {
+    position: absolute;
+    right: 18px;
+    bottom: 18px;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    border: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(15, 23, 42, 0.75);
+    color: #fff;
+    cursor: pointer;
+    transition: transform var(--transition-speed), background var(--transition-speed), opacity var(--transition-speed);
+    opacity: 0.88;
+}
+
+.audio-toggle:hover {
+    transform: scale(1.04);
+}
+
+.product-card:hover .audio-toggle,
+.product-card:focus-within .audio-toggle {
+    opacity: 1;
+}
+
+.audio-toggle:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+}
+
+.audio-toggle i {
+    pointer-events: none;
+}
+
+.product-card--with-audio .audio-toggle {
+    background: var(--color-accent);
+    color: #fff;
+    box-shadow: 0 12px 25px rgba(9, 90, 199, 0.35);
 }
 
 .product-info {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -269,6 +269,106 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    if (productCards.length > 0) {
+        const productVideoItems = Array.from(productCards)
+            .map(card => {
+                const video = card.querySelector('.product-video');
+                const control = card.querySelector('.audio-toggle');
+                return video ? { card, video, control } : null;
+            })
+            .filter(Boolean);
+
+        if (productVideoItems.length > 0) {
+            const attemptPlay = (video) => {
+                const playPromise = video.play();
+                if (playPromise && typeof playPromise.then === 'function') {
+                    playPromise.catch(() => {});
+                }
+            };
+
+            const pauseVideo = (video) => {
+                if (!video.paused) {
+                    video.pause();
+                }
+            };
+
+            const updateAudioControl = (item) => {
+                const { card, video, control } = item;
+                const isMuted = video.muted;
+                card.classList.toggle('product-card--with-audio', !isMuted);
+
+                if (control) {
+                    control.setAttribute('aria-pressed', String(!isMuted));
+                    control.setAttribute('aria-label', isMuted ? 'Activar audio del producto' : 'Desactivar audio del producto');
+
+                    const icon = control.querySelector('i');
+                    if (icon) {
+                        icon.classList.toggle('fa-volume-high', !isMuted);
+                        icon.classList.toggle('fa-volume-xmark', isMuted);
+                    }
+                }
+            };
+
+            const muteOtherVideos = (currentVideo) => {
+                productVideoItems.forEach(item => {
+                    if (item.video !== currentVideo && !item.video.muted) {
+                        item.video.muted = true;
+                        updateAudioControl(item);
+                    }
+                });
+            };
+
+            productVideoItems.forEach(item => {
+                const { card, video, control } = item;
+
+                const handlePlayRequest = () => attemptPlay(video);
+                const handlePauseRequest = () => pauseVideo(video);
+
+                card.addEventListener('pointerenter', handlePlayRequest);
+                card.addEventListener('pointerleave', handlePauseRequest);
+                card.addEventListener('pointercancel', handlePauseRequest);
+                card.addEventListener('pointerdown', handlePlayRequest);
+                card.addEventListener('pointerup', (event) => {
+                    const targetElement = event.target instanceof Element ? event.target : null;
+                    const interactedWithAudioToggle = targetElement ? targetElement.closest('.audio-toggle') : null;
+
+                    if (event.pointerType === 'touch' && !interactedWithAudioToggle) {
+                        handlePauseRequest();
+                    }
+                });
+                card.addEventListener('mouseenter', handlePlayRequest);
+                card.addEventListener('mouseleave', handlePauseRequest);
+                card.addEventListener('focusin', handlePlayRequest);
+                card.addEventListener('focusout', handlePauseRequest);
+
+                if (control) {
+                    control.addEventListener('click', (event) => {
+                        event.stopPropagation();
+
+                        if (video.muted) {
+                            muteOtherVideos(video);
+                            video.muted = false;
+                            handlePlayRequest();
+                        } else {
+                            video.muted = true;
+                        }
+
+                        updateAudioControl(item);
+                    });
+                }
+
+                video.addEventListener('volumechange', () => {
+                    updateAudioControl(item);
+                    if (!video.muted) {
+                        muteOtherVideos(video);
+                    }
+                });
+
+                updateAudioControl(item);
+            });
+        }
+    }
+
     // Inicializar listeners en la carga inicial de la página
     setupModalTriggers();
 });

--- a/productos.html
+++ b/productos.html
@@ -86,7 +86,12 @@
 
                 <div class="products-grid catalog-grid">
                     <div class="product-card" data-category="iphone">
-                        <img src="assets/images/iphone-promax-15.webp" alt="iPhone 15 Pro Max">
+                        <div class="product-media">
+                            <video class="product-video" src="assets/videos/large.mp4" poster="assets/images/iphone-promax-15.webp" playsinline muted loop preload="metadata"></video>
+                            <button type="button" class="audio-toggle" aria-label="Activar audio del producto" aria-pressed="false">
+                                <i class="fa-solid fa-volume-xmark" aria-hidden="true"></i>
+                            </button>
+                        </div>
                         <div class="product-info">
                             <h3 class="product-name">iPhone 15 Pro Max</h3>
                             <p class="product-spec">256GB · Titanio Natural · Incluye AppleCare opcional</p>
@@ -97,7 +102,12 @@
                     </div>
 
                     <div class="product-card" data-category="iphone">
-                        <img src="assets/images/Producto-iphone-venta.webp" alt="iPhone 13">
+                        <div class="product-media">
+                            <video class="product-video" src="assets/videos/large.mp4" poster="assets/images/Producto-iphone-venta.webp" playsinline muted loop preload="metadata"></video>
+                            <button type="button" class="audio-toggle" aria-label="Activar audio del producto" aria-pressed="false">
+                                <i class="fa-solid fa-volume-xmark" aria-hidden="true"></i>
+                            </button>
+                        </div>
                         <div class="product-info">
                             <h3 class="product-name">iPhone 13</h3>
                             <p class="product-spec">128GB · Colores disponibles · Garantía 12 meses</p>
@@ -108,7 +118,12 @@
                     </div>
 
                     <div class="product-card" data-category="android">
-                        <img src="assets/images/iphone-honor-presentación-hero.png" alt="HONOR y otros Android">
+                        <div class="product-media">
+                            <video class="product-video" src="assets/videos/large.mp4" poster="assets/images/iphone-honor-presentación-hero.png" playsinline muted loop preload="metadata"></video>
+                            <button type="button" class="audio-toggle" aria-label="Activar audio del producto" aria-pressed="false">
+                                <i class="fa-solid fa-volume-xmark" aria-hidden="true"></i>
+                            </button>
+                        </div>
                         <div class="product-info">
                             <h3 class="product-name">HONOR Magic &amp; aliados</h3>
                             <p class="product-spec">Pantallas OLED 120Hz · Cámaras Pro · Packs corporativos</p>
@@ -119,7 +134,12 @@
                     </div>
 
                     <div class="product-card" data-category="accesorios" id="baterias">
-                        <img src="assets/images/bateria-iphone-voltrax.webp" alt="Batería Voltrax para iPhone">
+                        <div class="product-media">
+                            <video class="product-video" src="assets/videos/large.mp4" poster="assets/images/bateria-iphone-voltrax.webp" playsinline muted loop preload="metadata"></video>
+                            <button type="button" class="audio-toggle" aria-label="Activar audio del producto" aria-pressed="false">
+                                <i class="fa-solid fa-volume-xmark" aria-hidden="true"></i>
+                            </button>
+                        </div>
                         <div class="product-info">
                             <h3 class="product-name">Baterías Voltrax y OEM</h3>
                             <p class="product-spec">Compatibles con iPhone y Android · Instalación en laboratorio</p>
@@ -130,7 +150,12 @@
                     </div>
 
                     <div class="product-card" data-category="accesorios">
-                        <img src="assets/images/producto-cargador-iphone (2).webp" alt="Cargador rápido para iPhone">
+                        <div class="product-media">
+                            <video class="product-video" src="assets/videos/large.mp4" poster="assets/images/producto-cargador-iphone (2).webp" playsinline muted loop preload="metadata"></video>
+                            <button type="button" class="audio-toggle" aria-label="Activar audio del producto" aria-pressed="false">
+                                <i class="fa-solid fa-volume-xmark" aria-hidden="true"></i>
+                            </button>
+                        </div>
                         <div class="product-info">
                             <h3 class="product-name">Cargadores rápidos</h3>
                             <p class="product-spec">USB-C, MagSafe y adaptadores de alta potencia certificados</p>
@@ -140,7 +165,12 @@
                     </div>
 
                     <div class="product-card" data-category="accesorios">
-                        <img src="assets/images/Altavoces-de-sonido-tematica-transformes.webp" alt="Altavoces temáticos Transformers">
+                        <div class="product-media">
+                            <video class="product-video" src="assets/videos/large.mp4" poster="assets/images/Altavoces-de-sonido-tematica-transformes.webp" playsinline muted loop preload="metadata"></video>
+                            <button type="button" class="audio-toggle" aria-label="Activar audio del producto" aria-pressed="false">
+                                <i class="fa-solid fa-volume-xmark" aria-hidden="true"></i>
+                            </button>
+                        </div>
                         <div class="product-info">
                             <h3 class="product-name">Altavoces edición Transformers</h3>
                             <p class="product-spec">Luces RGB · Bluetooth · Batería de larga duración</p>
@@ -151,7 +181,12 @@
                     </div>
 
                     <div class="product-card" data-category="accesorios">
-                        <img src="assets/images/cajas-de-audifono-inalambricos-tematicos.webp" alt="Audífonos inalámbricos temáticos">
+                        <div class="product-media">
+                            <video class="product-video" src="assets/videos/large.mp4" poster="assets/images/cajas-de-audifono-inalambricos-tematicos.webp" playsinline muted loop preload="metadata"></video>
+                            <button type="button" class="audio-toggle" aria-label="Activar audio del producto" aria-pressed="false">
+                                <i class="fa-solid fa-volume-xmark" aria-hidden="true"></i>
+                            </button>
+                        </div>
                         <div class="product-info">
                             <h3 class="product-name">Audífonos inalámbricos temáticos</h3>
                             <p class="product-spec">Estuches coleccionables · Cancelación de ruido · Ediciones limitadas</p>
@@ -162,7 +197,12 @@
                     </div>
 
                     <div class="product-card" data-category="accesorios">
-                        <img src="assets/images/producto-cabeza-de-cargador.webp" alt="Cabezal de cargador de alta gama">
+                        <div class="product-media">
+                            <video class="product-video" src="assets/videos/large.mp4" poster="assets/images/producto-cabeza-de-cargador.webp" playsinline muted loop preload="metadata"></video>
+                            <button type="button" class="audio-toggle" aria-label="Activar audio del producto" aria-pressed="false">
+                                <i class="fa-solid fa-volume-xmark" aria-hidden="true"></i>
+                            </button>
+                        </div>
                         <div class="product-info">
                             <h3 class="product-name">Adaptadores y hubs</h3>
                             <p class="product-spec">Soluciones de carga múltiple para hogares, negocios y autos</p>


### PR DESCRIPTION
## Summary
- wrap each product card media in a new `.product-media` container that shows a vertical autoplaying video with an audio toggle overlay
- style the new product media component with a 9:16 aspect ratio, hover/focus enhancements and audio-active state styles
- add JavaScript handlers that start/stop playback on hover/touch, toggle mute on click and keep only one product video unmuted at a time while syncing the control state

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc71022138832198737ee4ff8eee61