### PR TITLE
Move mobile navigation elements outside header

### DIFF
--- a/partials/header.html
+++ b/partials/header.html
@@ -34,35 +34,35 @@
             <span class="hamburger-line"></span>
         </button>
     </div>
-
-    <div id="mobile-nav" class="mobile-nav-container" aria-hidden="true">
-        <div class="mobile-nav-header">
-            <a href="index.html" class="mobile-logo">
-                <img src="assets/images/logo-iProperu.webp" alt="Logo de iPro Perú" class="logo-img">
-                <span>iPro Perú</span>
-            </a>
-            <button class="close-menu" aria-label="Cerrar menú">
-                <i class="fas fa-times"></i>
-            </button>
-        </div>
-
-        <nav class="mobile-nav" aria-label="Menú móvil">
-            <ul class="nav-links-mobile">
-                <li><a href="index.html" class="nav-link">Inicio</a></li>
-                <li><a href="servicios.html" class="nav-link">Servicio técnico</a></li>
-                <li><a href="productos.html" class="nav-link">Productos</a></li>
-                <li><a href="nosotros.html" class="nav-link">Nosotros</a></li>
-            </ul>
-        </nav>
-
-        <div class="mobile-nav-extra">
-            <a href="tel:+51979012180" class="mobile-link">
-                <i class="fa-solid fa-phone"></i> Llamar ahora
-            </a>
-            <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20agendar%20una%20reparaci%C3%B3n." target="_blank" class="main-cta-button mobile-cta">
-                Agendar reparación
-            </a>
-        </div>
-    </div>
-    <div class="nav-overlay" aria-hidden="true"></div>
 </header>
+
+<div id="mobile-nav" class="mobile-nav-container" aria-hidden="true">
+    <div class="mobile-nav-header">
+        <a href="index.html" class="mobile-logo">
+            <img src="assets/images/logo-iProperu.webp" alt="Logo de iPro Perú" class="logo-img">
+            <span>iPro Perú</span>
+        </a>
+        <button class="close-menu" aria-label="Cerrar menú">
+            <i class="fas fa-times"></i>
+        </button>
+    </div>
+
+    <nav class="mobile-nav" aria-label="Menú móvil">
+        <ul class="nav-links-mobile">
+            <li><a href="index.html" class="nav-link">Inicio</a></li>
+            <li><a href="servicios.html" class="nav-link">Servicio técnico</a></li>
+            <li><a href="productos.html" class="nav-link">Productos</a></li>
+            <li><a href="nosotros.html" class="nav-link">Nosotros</a></li>
+        </ul>
+    </nav>
+
+    <div class="mobile-nav-extra">
+        <a href="tel:+51979012180" class="mobile-link">
+            <i class="fa-solid fa-phone"></i> Llamar ahora
+        </a>
+        <a href="https://api.whatsapp.com/send?phone=51979012180&text=Hola%20iPro%20Per%C3%BA,%20quiero%20agendar%20una%20reparaci%C3%B3n." target="_blank" class="main-cta-button mobile-cta">
+            Agendar reparación
+        </a>
+    </div>
+</div>
+<div class="nav-overlay" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- close the main header immediately after the navigation surface and place the mobile drawer and overlay as sibling elements

## Testing
- Manual: Verified in a mobile viewport that opening the hamburger shows the drawer and overlay above the hero and keeps body scrolling locked while serving the site locally.


------
https://chatgpt.com/codex/tasks/task_e_68cc7ce7b7a4832185a0168b6a02dae2